### PR TITLE
Fix segfaults with exceptions

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -4,13 +4,13 @@ PHP_ARG_ENABLE(fiber, whether to enable fiber support,
 if test "$PHP_FIBER" != "no"; then
   AC_DEFINE(HAVE_FIBER, 1, [ Have fiber support ])
 
-  FIBER_CFLAGS="-z now -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  FIBER_CFLAGS=" -z now -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
 
   AC_CHECK_HEADER(ucontext.h, [
     FIBER_CFLAGS+=" -DHAVE_UCONTEXT_H=1"
   ])
   
-  LDFLAGS+="-z now"
+dnl  LDFLAGS+=" -z now"
   
   AC_MSG_CHECKING(for valgrind.h)
   

--- a/fiber_posix.c
+++ b/fiber_posix.c
@@ -150,7 +150,7 @@ ZEND_API void zend_fiber_destroy(zend_fiber_context ctx)
 #ifdef ZEND_FIBER_ASM
 
 void __attribute__ ((__noinline__, __regparm__(2)))
-zend_fiber_switch_context_asm(zend_fiber_context_posix *from, zend_fiber_context_posix *to);
+zend_fiber_switch_context_asm(zend_fiber_context_posix *from, zend_fiber_context_posix *to) asm("zend_fiber_switch_context_asm");
 
 asm (
 	"\t.text\n"

--- a/php_fiber.c
+++ b/php_fiber.c
@@ -159,6 +159,7 @@ static void zend_fiber_run()
 	fiber->exec->return_value = NULL;
 	fiber->exec->prev_execute_data = NULL;
 
+	EG(current_execute_data) = fiber->exec;
 	execute_ex(fiber->exec);
 
 	zend_vm_stack_destroy();
@@ -390,6 +391,10 @@ ZEND_METHOD(Fiber, throw)
 		return;
 	}
 
+	if (EG(exception)) {
+		return;
+	}
+
 	if (USED_RET()) {
 		RETURN_ZVAL(&fiber->value, 0, 0);
 	} else {
@@ -455,6 +460,10 @@ ZEND_METHOD(Fiber, yield)
 		zend_throw_exception_internal(error);
 		exec->opline++;
 
+		return;
+	}
+
+	if (EG(exception)) {
 		return;
 	}
 


### PR DESCRIPTION
Also fixing the build with macos, under macos `ld` does not know about `-z now` and errors out. Perhaps there is some feature checking possible, but not sure.
Also the name mangling of C compilers... Without `asm("zend_fiber_switch_context_asm")` it tries to find the symbol `_zend_switch_fiber_context_asm` instead of the symbol without underscore.

But the first commit (33e25ec333d13b8799e194adb68284ca7b465d62) should definitely be merged.